### PR TITLE
Do not index spack installed software with module spider unless explicitly requested

### DIFF
--- a/modules/spack/22.08-2.lua
+++ b/modules/spack/22.08-2.lua
@@ -81,9 +81,14 @@ setenv("SPACK_ROOT",spackroot)
 -- Override the user settings in the home directory
 setenv("SPACK_DISABLE_LOCAL_CONFIG","true")
 
--- Add Spack's modules
-prepend_path("MODULEPATH",userdir .. "/22.08/0.19.0/modules/tcl/linux-sles15-zen")
-prepend_path("MODULEPATH",userdir .. "/22.08/0.19.0/modules/tcl/linux-sles15-zen2")
-prepend_path("MODULEPATH","/appl/lumi/spack/22.08/0.19.0/share/spack/modules/linux-sles15-zen")
-prepend_path("MODULEPATH","/appl/lumi/spack/22.08/0.19.0/share/spack/modules/linux-sles15-zen2")
-
+-- Only make the MODULEPATH change visible to LMOD when loading, unloading or 
+-- showing a module to avoid interfereing with, e.g., module spider.
+-- With the exception that it can always be make visible to LMOD if 
+-- specifically requested through criteria coded in SitePackage.lua.
+if mode() == 'load' or mode() == 'unload' or mode() == 'show' or is_full_spider() then
+  -- Add Spack's modules
+  prepend_path("MODULEPATH",userdir .. "/22.08/0.19.0/modules/tcl/linux-sles15-zen")
+  prepend_path("MODULEPATH",userdir .. "/22.08/0.19.0/modules/tcl/linux-sles15-zen2")
+  prepend_path("MODULEPATH","/appl/lumi/spack/22.08/0.19.0/share/spack/modules/linux-sles15-zen")
+  prepend_path("MODULEPATH","/appl/lumi/spack/22.08/0.19.0/share/spack/modules/linux-sles15-zen2")
+end

--- a/modules/spack/22.08.lua
+++ b/modules/spack/22.08.lua
@@ -81,9 +81,17 @@ setenv("SPACK_ROOT",spackroot)
 -- Override the user settings in the home directory
 setenv("SPACK_DISABLE_LOCAL_CONFIG","true")
 
--- Add Spack's modules
-prepend_path("MODULEPATH",userdir .. "/22.08/0.18.1/modules/tcl/cray-sles15-zen")
-prepend_path("MODULEPATH",userdir .. "/22.08/0.18.1/modules/tcl/cray-sles15-zen2")
-prepend_path("MODULEPATH","/appl/lumi/spack/22.08/0.18.1/share/spack/modules/cray-sles15-zen")
-prepend_path("MODULEPATH","/appl/lumi/spack/22.08/0.18.1/share/spack/modules/cray-sles15-zen2")
+-- Check the spider mode
+local full_spider = os.getenv( 'LUMI_FULL_SPIDER' ) or 0
 
+-- Only make the MODULEPATH change visible to LMOD when loading, unloading or 
+-- showing a module to avoid interfereing with, e.g., module spider.
+-- With the exception that it can always be make visible to LMOD if 
+-- specifically requested through criteria coded in SitePackage.lua.
+if mode() == 'load' or mode() == 'unload' or mode() == 'show' or is_full_spider() then
+  -- Add Spack's modules
+  prepend_path("MODULEPATH",userdir .. "/22.08/0.18.1/modules/tcl/cray-sles15-zen")
+  prepend_path("MODULEPATH",userdir .. "/22.08/0.18.1/modules/tcl/cray-sles15-zen2")
+  prepend_path("MODULEPATH","/appl/lumi/spack/22.08/0.18.1/share/spack/modules/cray-sles15-zen")
+  prepend_path("MODULEPATH","/appl/lumi/spack/22.08/0.18.1/share/spack/modules/cray-sles15-zen2")
+end

--- a/modules/spack/23.03-2.lua
+++ b/modules/spack/23.03-2.lua
@@ -81,9 +81,17 @@ setenv("SPACK_ROOT",spackroot)
 -- Override the user settings in the home directory
 setenv("SPACK_DISABLE_LOCAL_CONFIG","true")
 
--- Add Spack's modules
-prepend_path("MODULEPATH",userdir .. "/23.03/0.20.0/modules/tcl/linux-sles15-zen")
-prepend_path("MODULEPATH",userdir .. "/23.03/0.20.0/modules/tcl/linux-sles15-zen2")
-prepend_path("MODULEPATH","/appl/lumi/spack/23.03/0.20.0/share/spack/modules/linux-sles15-zen")
-prepend_path("MODULEPATH","/appl/lumi/spack/23.03/0.20.0/share/spack/modules/linux-sles15-zen2")
+-- Check the spider mode
+local full_spider = os.getenv( 'LUMI_FULL_SPIDER' ) or 0
 
+-- Only make the MODULEPATH change visible to LMOD when loading, unloading or 
+-- showing a module to avoid interfereing with, e.g., module spider.
+-- With the exception that it can always be make visible to LMOD if 
+-- specifically requested through criteria coded in SitePackage.lua.
+if mode() == 'load' or mode() == 'unload' or mode() == 'show' or is_full_spider() then
+  -- Add Spack's modules
+  prepend_path("MODULEPATH",userdir .. "/23.03/0.20.0/modules/tcl/linux-sles15-zen")
+  prepend_path("MODULEPATH",userdir .. "/23.03/0.20.0/modules/tcl/linux-sles15-zen2")
+  prepend_path("MODULEPATH","/appl/lumi/spack/23.03/0.20.0/share/spack/modules/linux-sles15-zen")
+  prepend_path("MODULEPATH","/appl/lumi/spack/23.03/0.20.0/share/spack/modules/linux-sles15-zen2")
+end

--- a/modules/spack/23.03.lua
+++ b/modules/spack/23.03.lua
@@ -81,9 +81,17 @@ setenv("SPACK_ROOT",spackroot)
 -- Override the user settings in the home directory
 setenv("SPACK_DISABLE_LOCAL_CONFIG","true")
 
--- Add Spack's modules
-prepend_path("MODULEPATH",userdir .. "/23.03/0.19.2/modules/tcl/linux-sles15-zen")
-prepend_path("MODULEPATH",userdir .. "/23.03/0.19.2/modules/tcl/linux-sles15-zen2")
-prepend_path("MODULEPATH","/appl/lumi/spack/23.03/0.19.2/share/spack/modules/linux-sles15-zen")
-prepend_path("MODULEPATH","/appl/lumi/spack/23.03/0.19.2/share/spack/modules/linux-sles15-zen2")
+-- Check the spider mode
+local full_spider = os.getenv( 'LUMI_FULL_SPIDER' ) or 0
 
+-- Only make the MODULEPATH change visible to LMOD when loading, unloading or 
+-- showing a module to avoid interfereing with, e.g., module spider.
+-- With the exception that it can always be make visible to LMOD if 
+-- specifically requested through criteria coded in SitePackage.lua.
+if mode() == 'load' or mode() == 'unload' or mode() == 'show' or is_full_spider() then
+  -- Add Spack's modules
+  prepend_path("MODULEPATH",userdir .. "/23.03/0.19.2/modules/tcl/linux-sles15-zen")
+  prepend_path("MODULEPATH",userdir .. "/23.03/0.19.2/modules/tcl/linux-sles15-zen2")
+  prepend_path("MODULEPATH","/appl/lumi/spack/23.03/0.19.2/share/spack/modules/linux-sles15-zen")
+  prepend_path("MODULEPATH","/appl/lumi/spack/23.03/0.19.2/share/spack/modules/linux-sles15-zen2")
+end

--- a/modules/spack/23.09.lua
+++ b/modules/spack/23.09.lua
@@ -81,8 +81,17 @@ setenv("SPACK_ROOT",spackroot)
 -- Override the user settings in the home directory
 setenv("SPACK_DISABLE_LOCAL_CONFIG","true")
 
--- Add Spack's modules
-prepend_path("MODULEPATH",userdir .. "/23.09/0.21.0/modules/tcl/linux-sles15-zen")
-prepend_path("MODULEPATH",userdir .. "/23.09/0.21.0/modules/tcl/linux-sles15-zen2")
-prepend_path("MODULEPATH","/appl/lumi/spack/23.09/0.21.0/share/spack/modules/linux-sles15-zen")
-prepend_path("MODULEPATH","/appl/lumi/spack/23.09/0.21.0/share/spack/modules/linux-sles15-zen2")
+-- Check the spider mode
+local full_spider = os.getenv( 'LUMI_FULL_SPIDER' ) or 0
+
+-- Only make the MODULEPATH change visible to LMOD when loading, unloading or 
+-- showing a module to avoid interfereing with, e.g., module spider.
+-- With the exception that it can always be make visible to LMOD if 
+-- specifically requested through criteria coded in SitePackage.lua.
+if mode() == 'load' or mode() == 'unload' or mode() == 'show' or is_full_spider() then
+  -- Add Spack's modules
+  prepend_path("MODULEPATH",userdir .. "/23.09/0.21.0/modules/tcl/linux-sles15-zen")
+  prepend_path("MODULEPATH",userdir .. "/23.09/0.21.0/modules/tcl/linux-sles15-zen2")
+  prepend_path("MODULEPATH","/appl/lumi/spack/23.09/0.21.0/share/spack/modules/linux-sles15-zen")
+  prepend_path("MODULEPATH","/appl/lumi/spack/23.09/0.21.0/share/spack/modules/linux-sles15-zen2")
+end


### PR DESCRIPTION
As discussed with Radim during a coffee break.

Rationale: The spack modules cause trouble for users not familiar with spack or users in general:

* Some spack modules hide software installed with EasyBuild in the output of module spider simply because of the spelling they use. The case insensitive search in Lmod will stop if it has found a suitable module and not look into extensions anymore.
* The cryptic names are hard to explain to users in a course, even more so because there seem to be different systems in use (cmake/version and cmake-version, the latter for the system compiler?, in some stacks...)
* The spack modules are the main cause of extremely slow response of module spider and module avail when the cache has to be rebuild, and there are two causes:
  * The modules that Spack generates are Tcl modules which are processed a lot slower by Lmod as they are first converted to Lua, then interpreted by Lua. The conversion process is rather inefficient and takes a lot more time than actually executing the lua code. The spider build mechanism actually executes each module file in spider mode...
  * And there are simply a lot of modules in the Spack setup. Can someone give a reasonable explanation why we need 8 cmake/3.26.3 modules compiled with gcc (of which 6 for zen2, it turns out with 2 versions of gcc) and two with a different name structure that seem to be compiled with the system gcc in just the spack/23.03-2 stack? And since spack generates a module for each X11 library or Python package, that also generates an explosion of module files.
  * This has become really troublesome with the growth of the number of Spack installations offered and the tendency to install a lot of packages into each stack and not using it to create clean environments, which help lead to an explosion of variants of packages as the concretiser cannot find an optimal solution for the needs.

The implementation is done by hiding intended changes to MODULEPATH unless spack is loading, unloading or showing a module, or unless it is explicitly requested to index all packages. The latter is implemented in the is_full_spider() function defined in SitePackage.lua, so that we can change the criteria for full indexing without having to go through all the modules again.